### PR TITLE
Correction some errors in Catalogue and Distribution

### DIFF
--- a/Catalogue/schema.json
+++ b/Catalogue/schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/schema#",
   "$schemaVersion": "0.0.1",
-  "modelTags": "",
+  "modelTags": "INTERSTAT",
   "$id": "https://smart-data-models.github.io/dataModel.STAT-DCAT-AP/Catalogue/schema.json",
   "title": " Smart Data Models - STAT-DCAT-AP Catalogue",
   "description": "Catalogue of datasets compliant with STAT-DCAT-AP 1.0.1 specification.",

--- a/Distribution/ADOPTERS.yaml
+++ b/Distribution/ADOPTERS.yaml
@@ -6,5 +6,5 @@ currentAdopters:
  mail:
  organization:
  project:  https://cef-interstat.eu/
- comments: SKOS Concept class defined to be used into statDCAT-AP
+ comments: A physical embodiment of the Dataset in a particular format, including visualisations of the data (http://www.w3.org/TR/2013/WD-vocab-dcat-20130312/#class-distribution).
  startDate: 2023-02-23

--- a/Distribution/schema.json
+++ b/Distribution/schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/schema",
   "$schemaVersion": "0.0.1",
-  "modelTags": "",
+  "modelTags": "INTERSTAT",
   "$id": "https://github.com/smart-data-models/dataModel.STAT-DCAT-AP/blob/master/Distribution/schema.json",
   "title": "Smart Data models STAT-DCAT-AP distribution of a Dataset,",
   "description": "This is a distribution belonging ot a dataset according to the STAT-DCAT-AP standard 1.0.1",
@@ -38,7 +38,7 @@
           "type": "string",
           "description": "Property. Model:'https://schema.org/Text'. This property refers to the file format of the Distribution."
         },
-        "license": {
+        "licence": {
           "type": "string",
           "description": "Property. Model:'dct:license'. This property refers to the licence under which the Distribution is made available."
         },
@@ -94,7 +94,7 @@
         },
         "status": {
           "type": "string",
-          "description": "Property. Model:'adms :status'. This property refers to the maturity of the Distribution."
+          "description": "Property. Model:'adms:status'. This property refers to the maturity of the Distribution."
         },
         "title": {
           "type": "array",


### PR DESCRIPTION
- Correction a typo about Distribution:licence as it is declared in the statDCAT-AP specification 1.0.1
- Updated modelTags in Distribution schema
- Correct ADOPTERS comment in Distribution data model
- Deletion blank space in the definition of the Model in Distribution:status